### PR TITLE
Update Spark Loading Notebook To Fix and Cleanup

### DIFF
--- a/load_from_data_engg_nb.ipynb
+++ b/load_from_data_engg_nb.ipynb
@@ -1,10 +1,36 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "source": [
+    "# Neo4j Data Load\n",
+    "An example with the Northwind sample database."
+   ],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "325089aa-3594-4f56-95cd-612a7b159ca4"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Setup"
+   ],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "db2fa97b-fd65-45d8-b130-615ec1149a20"
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%%spark\n",
     "\n",
@@ -18,9 +44,98 @@
     "import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper\n",
     "\n",
     "// Create Spark session\n",
-    "val spark = SparkSession.builder().appName(\"Neo4j Notebook\").getOrCreate()\n",
+    "val spark = SparkSession.builder().appName(\"Neo4j Notebook\").getOrCreate()\n"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false,
+     "outputs_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    },
+    "microsoft": {
+     "language": "scala"
+    }
+   },
+   "id": "7e125217-c74d-44b0-b7cd-858c620b93a7"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Read Northwind Files from Lakehouse"
+   ],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "8797f900-c3f1-4265-909f-e40b45e96cfb"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "// Read Northwind data files\n",
+    "val customerDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"customers.csv\")\n",
+    "val supplierDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"suppliers.csv\")\n",
+    "val stagedOrderDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"orders.csv\")\n",
+    "  .withColumn(\"addressID\", concat_ws(\", \", col(\"shipName\"), col(\"shipAddress\"), \n",
+    "  col(\"shipCity\"), col(\"shipRegion\"), col(\"shipPostalCode\"), col(\"shipCountry\")))\n",
+    "val orderDetailDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"order-details.csv\")\n",
+    "val productDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"products.csv\")\n",
+    "val categoryDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"categories.csv\")\n",
     "\n",
-    "// Load JSON file\n",
+    "//create seperate addressesDF and finalize orderDF\n",
+    "val addressDF = stagedOrderDF\n",
+    " .select($\"addressID\", \n",
+    "    $\"shipName\".alias(\"name\"), \n",
+    "    $\"shipAddress\".alias(\"address\"), \n",
+    "    $\"shipCity\".alias(\"city\"), \n",
+    "    $\"shipRegion\".alias(\"region\"), \n",
+    "    $\"shipPostalCode\".alias(\"postalCode\"), \n",
+    "    $\"shipCountry\".alias(\"country\"))\n",
+    " .dropDuplicates(\"addressID\")\n",
+    "val orderDF = stagedOrderDF.drop(\"shipName\",\"shipAddress\", \"shipCity\", \"shipRegion\", \"shipPostalCode\", \"shipCountry\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false,
+     "outputs_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "dd488327-b3ea-4895-b103-0c854e49fc54"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Write Nodes into Neo4j"
+   ],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "468b602e-b086-4c74-81ce-be26a924a2cc"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "// Load JSON file for Neo4j credentials\n",
     "val jsonString = spark.read.text(absfss_Base_Path + \"neo4j-conn.json\").as[String].collect().mkString(\"\\n\")\n",
     "\n",
     "// Parse JSON string\n",
@@ -33,44 +148,9 @@
     "val neo4jUsername = data(\"neo4j-username\").asInstanceOf[String]\n",
     "val neo4jPassword = data(\"neo4j-password\").asInstanceOf[String]\n",
     "\n",
-    "// Read Northwind data files\n",
-    "val customerDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"customers.csv\")\n",
-    "val supplierDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"suppliers.csv\")\n",
-    "val orderDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"orders.csv\")\n",
-    "val orderDetailDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"order-details.csv\")\n",
-    "val productDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"products.csv\")\n",
-    "val categoryDF = spark.read.option(\"header\", true).csv(absfss_Base_Path + \"categories.csv\")\n",
     "\n",
-    "// Cypher statements\n",
-    "val cypherStmtCreateCustConstraint =\n",
-    "  \"CREATE CONSTRAINT IF NOT EXISTS FOR (n:Customer) REQUIRE (n.customerID) IS NODE KEY;\"\n",
-    "val cypherStmtCreateOrderConstraint =\n",
-    "  \"CREATE CONSTRAINT IF NOT EXISTS FOR (n:Order) REQUIRE (n.orderID) IS NODE KEY;\"\n",
-    "val cypherStmtCreateProdConstraint =\n",
-    "  \"CREATE CONSTRAINT IF NOT EXISTS FOR (n:Product) REQUIRE (n.productID) IS NODE KEY;\"\n",
-    "val cypherStmtCreateSupplierConstraint =\n",
-    "  \"CREATE CONSTRAINT IF NOT EXISTS FOR (n:Supplier) REQUIRE (n.supplierID) IS NODE KEY;\"\n",
-    "\n",
-    "// Execute Cypher statements\n",
-    "def executeCypher(spark: SparkSession, cypherStatement: String): Unit = {\n",
-    "  spark\n",
-    "    .read.format(\"org.neo4j.spark.DataSource\")\n",
-    "    .option(\"url\", neo4jUrl)\n",
-    "    .option(\"authentication.basic.username\", neo4jUsername)\n",
-    "    .option(\"authentication.basic.password\", neo4jPassword)\n",
-    "    .option(\"query\", cypherStatement)\n",
-    "    .load()\n",
-    "}\n",
-    "\n",
-    "// Execute Cypher statements to create constraints\n",
-    "executeCypher(spark, cypherStmtCreateCustConstraint)\n",
-    "executeCypher(spark, cypherStmtCreateOrderConstraint)\n",
-    "executeCypher(spark, cypherStmtCreateProdConstraint)\n",
-    "executeCypher(spark, cypherStmtCreateSupplierConstraint)\n",
-    "\n",
-    "\n",
-    "// Write data to Neo4j\n",
-    "def writeToNeo4j(dataFrame: DataFrame, label: String, nodeKey: String, relationship: Option[String] = None): Unit = {\n",
+    "// Write nodes to Neo4j\n",
+    "def writeNodesToNeo4j(dataFrame: DataFrame, label: String, nodeKey: String): Unit = {\n",
     "  dataFrame.write.format(\"org.neo4j.spark.DataSource\")\n",
     "    .mode(SaveMode.Overwrite)\n",
     "    .option(\"url\", neo4jUrl)\n",
@@ -78,31 +158,160 @@
     "    .option(\"authentication.basic.password\", neo4jPassword)\n",
     "    .option(\"labels\", label)\n",
     "    .option(\"node.keys\", nodeKey)\n",
+    "    .option(\"schema.optimization.node.keys\", \"KEY\") //create node key constraints under the hood\n",
     "    .save()\n",
     "}\n",
     "\n",
-    "// Write nodes to Neo4j\n",
-    "writeToNeo4j(customerDF, \":Customer\", \"customerID\")\n",
-    "writeToNeo4j(supplierDF, \":Supplier\", \"supplierID\")\n",
-    "writeToNeo4j(orderDF, \":Order\", \"orderID\")\n",
-    "writeToNeo4j(orderDetailDF, \":Order_Detail\", \"orderID\")\n",
-    "writeToNeo4j(productDF, \":Product\", \"productID\")\n",
-    "writeToNeo4j(categoryDF, \":Category\", \"categoryID\")\n",
-    "\n",
+    "writeNodesToNeo4j(customerDF, \"Customer\", \"customerID\")\n",
+    "writeNodesToNeo4j(supplierDF, \"Supplier\", \"supplierID\")\n",
+    "writeNodesToNeo4j(orderDF, \"Order\", \"orderID\")\n",
+    "writeNodesToNeo4j(productDF, \"Product\", \"productID\")\n",
+    "writeNodesToNeo4j(categoryDF, \"Category\", \"categoryID\")\n",
+    "writeNodesToNeo4j(addressDF, \"Address\", \"addressID\")"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false,
+     "outputs_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "6b8f5eff-b529-4ffa-8d19-11345d5aad2f"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Write Relationships into Neo4j"
+   ],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "418e28d5-c547-4a09-97b7-833d174877b5"
+  },
+  {
+   "cell_type": "code",
+   "source": [
     "// Write relationships to Neo4j\n",
-    "writeToNeo4j(productDF, \":Product\", \"productID\", Some(\"PRODUCT-CATEGORY\"))\n",
-    "writeToNeo4j(productDF, \":Supplier\", \"supplierID\", Some(\"SUPPLIER-PRODUCT\"))\n",
-    "writeToNeo4j(orderDetailDF, \":Order\", \"orderID\", Some(\"ORDER-PRODUCT\"))\n",
-    "writeToNeo4j(orderDF, \":Customer\", \"customerID\", Some(\"CUSTOMER-ORDERED\"))\n"
-   ]
+    "\n",
+    "case class NodeInfo(labels:String, keys:String)  \n",
+    "\n",
+    "def writeRelsToNeo4j(dataFrame: DataFrame, sourceNode: NodeInfo, relType: String, targetNode: NodeInfo): Unit = {\n",
+    "  dataFrame.write.format(\"org.neo4j.spark.DataSource\")\n",
+    "    .mode(SaveMode.Overwrite)\n",
+    "    .option(\"url\", neo4jUrl)\n",
+    "    .option(\"authentication.basic.username\", neo4jUsername)\n",
+    "    .option(\"authentication.basic.password\", neo4jPassword)\n",
+    "    .option(\"relationship.save.strategy\", \"keys\")\n",
+    "    .option(\"relationship\", relType)\n",
+    "    .option(\"relationship.source.save.mode\", \"Match\")\n",
+    "    .option(\"relationship.source.labels\", sourceNode.labels)\n",
+    "    .option(\"relationship.source.node.keys\", sourceNode.keys)\n",
+    "    .option(\"relationship.target.save.mode\", \"Match\")\n",
+    "    .option(\"relationship.target.labels\", targetNode.labels)\n",
+    "    .option(\"relationship.target.node.keys\", targetNode.keys)\n",
+    "    .save()\n",
+    "}\n",
+    "\n",
+    "writeRelsToNeo4j(productDF.select($\"productID\", $\"categoryID\"), NodeInfo(\"Product\", \"productID\"), \"BELONGS_TO\", NodeInfo(\"Category\", \"categoryID\"))\n",
+    "writeRelsToNeo4j(productDF.select($\"productID\", $\"supplierID\"), NodeInfo(\"Product\", \"productID\"), \"SUPPLIED_BY\", NodeInfo(\"Supplier\", \"supplierID\"))\n",
+    "writeRelsToNeo4j(orderDetailDF.select($\"orderID\", $\"productID\"), NodeInfo(\"Order\", \"orderID\"), \"ORDER_CONTAINS\", NodeInfo(\"Product\", \"productID\"))\n",
+    "writeRelsToNeo4j(orderDF.select($\"customerID\", $\"orderID\"), NodeInfo(\"Customer\", \"customerID\"), \"ORDERED\", NodeInfo(\"Order\", \"orderID\"))\n",
+    "writeRelsToNeo4j(orderDF.select($\"orderID\", $\"addressID\"), NodeInfo(\"Order\", \"orderID\"), \"SHIPPED_TO\", NodeInfo(\"Address\", \"addressID\"))"
+   ],
+   "outputs": [],
+   "execution_count": null,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": false,
+     "outputs_hidden": false
+    },
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    },
+    "microsoft": {}
+   },
+   "id": "644cc5b9-03d4-444b-b7a0-ec117ed15984"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [],
+   "metadata": {
+    "nteract": {
+     "transient": {
+      "deleting": false
+     }
+    }
+   },
+   "id": "d1c05ccd-eccc-4f44-9ff5-a5c12fbd2720"
   }
  ],
  "metadata": {
-  "language_info": {
-   "name": "python"
+  "microsoft": {
+   "language": "scala",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
   },
-  "orig_nbformat": 4
+  "widgets": {},
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
+  "language_info": {
+   "name": "scala"
+  },
+  "kernelspec": {
+   "name": "synapse_pyspark",
+   "language": "Python",
+   "display_name": "Synapse PySpark"
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "notebook_environment": {},
+  "synapse_widget": {
+   "version": "0.1",
+   "state": {}
+  },
+  "save_output": true,
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "enableDebugMode": false,
+    "conf": {}
+   }
+  },
+  "trident": {
+   "lakehouse": {
+    "default_lakehouse": "e799d13f-8cb1-4a9d-9a56-f9b982ffaa32",
+    "known_lakehouses": [
+     {
+      "id": "c2659cf5-f9c2-40d0-8ed8-87c730f007a0"
+     },
+     {
+      "id": "e799d13f-8cb1-4a9d-9a56-f9b982ffaa32"
+     }
+    ],
+    "default_lakehouse_name": "Northwind_Lakehouse",
+    "default_lakehouse_workspace_id": "e729ec52-47e8-4b70-b69d-11498a383d76"
+   },
+   "environment": {
+    "environmentId": "c265535a-b67a-46eb-8547-f0d5df2624db",
+    "workspaceId": "e729ec52-47e8-4b70-b69d-11498a383d76"
+   }
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
- Fixed to actually load relationships. Created separate relationship load function.
- Renamed relationship types to not use hyphens and to match the schema of other loading scripts
- Updated DataSource writer configurations to clean up and make more efficient. Includes automatically setting node key constraints and using MATCH logic in relationship load.
- Removed custom Cypher queries for setting constraints (now taken care of in write config)
- Added Markdown and split code into multiple cells to make easier to follow along